### PR TITLE
Possible fix for being unable to see SIM contacts

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -325,4 +325,7 @@
         <item>"/system/framework/arm64/boot.oat"</item>
         <item>"/system/framework/arm64/boot-core-libart.oat"</item>
     </string-array>
+ 
+    <!-- Configuration to support SIM contact batch operation -->
+    <bool name="config_sim_phonebook_batch_operation">false</bool>
 </resources>


### PR DESCRIPTION
I'm unable to see any contacts that are stored on my SIM card, tried various ones, the contacts app just acts like there is no SIM. I found this here: https://github.com/LineageOS/android_device_motorola_msm8916-common/blob/3ee91a47c2c91bc97f583195aa4f0dc7497aa4a8/overlay/frameworks/base/core/res/res/values/config.xml

so I do not know if this will have any effect for the Axon 7, maybe somebody knows more here, but I couldn't really find a solution.